### PR TITLE
Fixes Typo in instructions in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ You may now use the latest JS features and have it work on essentially all brows
 <h4 id="get-https-cdn-jsdelivr-net-polyfills-polyfill-js-polyfills-">GET <a href="https://cdn.jsdelivr.net/polyfills/polyfill.js">https://cdn.jsdelivr.net/polyfills/polyfill.js</a> ± [polyfills...]</h4>
 <p>Returns a JavaScript bundle of polyfills based on the current <code>User-Agent</code>.
 You may either include or exclude a <code>,</code>-delimited list of polyfills.
-To include polyfills, use a <code>-</code>, otherwise, use a <code>+</code>.
+To exclude polyfills, use a <code>-</code>, otherwise, use a <code>+</code>.
 You select each polyfill by its <code>slug</code> listed below.</p>
 <p>Examples:</p>
 <pre><code class="lang-html"><span class="hljs-comment">&lt;!-- RECOMMENDED: include everything but Element.prototype.classList and Element.prototype.matches(), both of which are handled by the dom4 polyfill! --&gt;</span>


### PR DESCRIPTION
The instructions under the 'API' heading said 'To include polyfils use a -', it should say, 'To exclude polyfils use a -'